### PR TITLE
Switch to using PackageLicenseExpression

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -17,7 +17,7 @@ foreach ($src in ls $PSScriptRoot\..\src/*) {
         $version = $BuildVersionNumber
     }
 
-    & dotnet build -c Release
+    & dotnet build -c Release /p:ContinuousIntegrationBuild=True
     & dotnet pack -c Release --include-symbols -o ..\..\artifacts --no-build /p:PackageVersion=$version
     if($LASTEXITCODE -ne 0) { exit 1 }    
 

--- a/src/Flurl.Http.Xml/Flurl.Http.Xml.csproj
+++ b/src/Flurl.Http.Xml/Flurl.Http.Xml.csproj
@@ -6,33 +6,27 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Luk Vermeulen</Authors>
-    <PackageLicenseUrl>https://github.com/lvermeulen/Flurl.Http.Xml/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/lvermeulen/Flurl.Http.Xml</PackageProjectUrl>
     <Copyright>Copyright 2016-2020 by Luk Vermeulen. All rights reserved.</Copyright>
     <RepositoryUrl>https://github.com/lvermeulen/Flurl.Http.Xml</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Flurl;Http;Xml</PackageTags>
-    <PackageIconUrl>http://i.imgur.com/llEKpRL.png?1</PackageIconUrl>
+    <PackageIcon>icon.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>XML extensions to Flurl.Http</Description>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Flurl.Http" Version="4.0.0" />
-    <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45'">
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4'">
-    <PackageReference Include="System.Xml.XPath.XDocument" Version="4.3.0" />
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" Visible="false" PackagePath="README.md"/>
+    <None Include="..\..\assets\noun_320630_cc.png" Pack="true" Visible="false" PackagePath="icon.png"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
* license expression is the preferred way (shows in NuGet.org and used in license validations)
* use `PackageIcon` instead of deprecated URL
* remove unnecessary package references
* ensure deterministic build in `build.ps1`
* added package README.md which is endorsed by NuGet team

Now issues reported by NuGet Package Explorer should be fixed: https://nuget.info/packages/Flurl.Http.Xml/4.0.0